### PR TITLE
!(typeof(value) === 'undefined' && value === "") is a tautology

### DIFF
--- a/app/utils/validate.js
+++ b/app/utils/validate.js
@@ -1,7 +1,7 @@
 exports.validate = function(value, constraints, errorMessage){
     var result = true;
     
-    if(typeof(value) === 'undefined' && value === ""){
+    if(typeof(value) === 'undefined' || value === ""){
         alert("Test" + errorMessage);
         return false;
     }


### PR DESCRIPTION
`!(typeof(value) === 'undefined' && value === "")` is a tautology, 
thus `(typeof(value) === 'undefined' && value === ""` is always false!

It should be `typeof(value) === 'undefined' || value === ""`